### PR TITLE
fix: add missing int32 and float32 types

### DIFF
--- a/.changelog/39.txt
+++ b/.changelog/39.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Add missing `int32` and `float32` types in the ElementType
+```

--- a/attrtypes.go
+++ b/attrtypes.go
@@ -66,8 +66,12 @@ func ElementType[T any](_ context.Context) (attr.Type, error) {
 		return StringType{}, nil
 	case reflect.Bool:
 		return BoolType{}, nil
+	case reflect.Int32:
+		return Int32Type{}, nil
 	case reflect.Int64:
 		return Int64Type{}, nil
+	case reflect.Float32:
+		return Float32Type{}, nil
 	case reflect.Float64:
 		return Float64Type{}, nil
 	default:

--- a/attrtypes_test.go
+++ b/attrtypes_test.go
@@ -65,8 +65,10 @@ func TestElementType(t *testing.T) {
 	t.Parallel()
 
 	type String string
+	type Int32 int32
 	type Int64 int64
 	type Bool bool
+	type Float32 float32
 	type Float64 float64
 	type Invalid int
 
@@ -77,6 +79,15 @@ func TestElementType(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, supertypes.StringType{}); diff != "" {
+		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+	}
+
+	got, err = supertypes.ElementType[Int32](ctx)
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	if diff := cmp.Diff(got, supertypes.Int32Type{}); diff != "" {
 		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 	}
 
@@ -95,6 +106,15 @@ func TestElementType(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, supertypes.BoolType{}); diff != "" {
+		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+	}
+
+	got, err = supertypes.ElementType[Float32](ctx)
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	if diff := cmp.Diff(got, supertypes.Float32Type{}); diff != "" {
 		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
 	}
 


### PR DESCRIPTION
Add missing `int32` and `float32` types in the `ElementType`.