### PR TITLE
feat: implement Float64SemanticEquals

### DIFF
--- a/float64_value.go
+++ b/float64_value.go
@@ -23,12 +23,16 @@ package supertypes
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
 var _ basetypes.Float64Valuable = Float64Value{}
+var _ basetypes.Float64ValuableWithSemanticEquals = Float64Value{}
 
 type Float64Value struct {
 	basetypes.Float64Value
@@ -48,6 +52,25 @@ func (v Float64Value) Type(ctx context.Context) attr.Type {
 	return Float64Type{
 		Float64Type: v.Float64Value.Type(ctx).(basetypes.Float64Type),
 	}
+}
+
+func (f Float64Value) Float64SemanticEquals(ctx context.Context, newValuable basetypes.Float64Valuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(Float64Value)
+	if ok {
+		return f.ValueFloat64() == newValue.ValueFloat64(), diags
+	}
+
+	diags.AddError(
+		"Semantic Equality Check Error",
+		"An unexpected value type was received while performing semantic equality checks. "+
+			"Please report this to the provider developers.\n\n"+
+			"Expected Value Type: "+fmt.Sprintf("%T", f)+"\n"+
+			"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+	)
+
+	return false, diags
 }
 
 func NewFloat64Null() Float64Value {

--- a/float64_value_test.go
+++ b/float64_value_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -490,4 +491,51 @@ func TestFloat64Value(t *testing.T) {
 		v := NewFloat64Value(1.23)
 		assert.IsType(t, Float64Type{}, v.Type(context.Background()))
 	})
+}
+
+func TestFloat64ValueFloat64SemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		currentFloat64 Float64Value
+		givenFloat64   Float64Value
+		expectedMatch  bool
+		expectedDiags  diag.Diagnostics
+	}{
+		"not equal - whole number": {
+			currentFloat64: NewFloat64Value(1),
+			givenFloat64:   NewFloat64Value(2),
+			expectedMatch:  false,
+		},
+		"not equal - float": {
+			currentFloat64: NewFloat64Value(1.1),
+			givenFloat64:   NewFloat64Value(1.2),
+			expectedMatch:  false,
+		},
+		"semantically equal - whole number": {
+			currentFloat64: NewFloat64Value(1),
+			givenFloat64:   NewFloat64Value(1),
+			expectedMatch:  true,
+		},
+		"semantically equal - float": {
+			currentFloat64: NewFloat64Value(1.1),
+			givenFloat64:   NewFloat64Value(1.1),
+			expectedMatch:  true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			match, diags := testCase.currentFloat64.Float64SemanticEquals(context.Background(), testCase.givenFloat64)
+
+			if testCase.expectedMatch != match {
+				t.Errorf("Expected Float64SemanticEquals to return: %t, but got: %t", testCase.expectedMatch, match)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR fixes a **Semantic Equality Check Error** error that occurs during resource lifecycle evaluation (such as plan or apply phases).

When the framework performs semantic equality checks on certain float fields, it encounters a type mismatch error:

```
Error: Semantic Equality Check Error

  with sentry_metric_monitor.test,
  on terraform_plugin_test.tf line 19, in resource "sentry_metric_monitor" "test":
  19:           resource "sentry_metric_monitor" "test" {

An unexpected value type was received while performing semantic equality
checks. Please report this to the provider developers.

Expected Value Type: basetypes.Float64Value
Got Value Type: supertypes.Float64Value
```

Internally, [`basetypes.Float64Value`'s implementation of `Float64SemanticEquals` was performing a rigid type assertion/cast expecting another `basetypes.Float64Value`](https://github.com/hashicorp/terraform-plugin-framework/blob/0732fe4246cc66ebc1698953175982bb9ae830a1/types/basetypes/float64_value.go#L101C1-L118C2).

However, when custom modifiers or advanced schema definitions are used, the framework passes down a `supertypes.Float64Value.` Because Go treats these as distinct underlying types despite their structural similarities, the internal casting failed, triggering the framework's semantic equality safety guardrails.

Added `Float64SemanticEquals` to properly handle and cast the incoming value to `supertypes.Float64Value`, ensuring that comparisons between the base type and its wrapped supertype successfully evaluate without raising a type mismatch exception.
